### PR TITLE
Sign out user patch

### DIFF
--- a/src/api/firebaseUtils.ts
+++ b/src/api/firebaseUtils.ts
@@ -1056,7 +1056,6 @@ export const deleteAccount = async (userId: string) => {
 };
 
 export const queryUserEventLogs = async (uid: string, limitNum: number = 3): Promise<Array<UserEventData>> => {
-    console.log(`users/${uid}/event-logs`);
     const userEventLogsCollectionRef = collection(db, `users/${uid}/event-logs`);
     const q = query(userEventLogsCollectionRef, orderBy('signInTime', 'desc'), limit(limitNum));
     const eventLogSnapshot = await getDocs(q);

--- a/src/context/UserContext.tsx
+++ b/src/context/UserContext.tsx
@@ -30,9 +30,9 @@ const UserProvider: React.FC<UserProviderProps> = ({ children }) => {
   const [userLoading, setUserLoading] = useState<boolean>(true);
   const [userInfo, setUserInfo] = useState<User | undefined>(undefined)
 
-  const signOutUser = async (hasExpoPushToken: boolean) => {
+  const signOutUser = async (deleteExpoPushToken: boolean) => {
     try {
-      if (hasExpoPushToken) {
+      if (deleteExpoPushToken) {
         await removeExpoPushToken();
       }
       await signOut(auth);
@@ -78,7 +78,7 @@ type UserContextType = {
   setUserInfo: React.Dispatch<React.SetStateAction<User | undefined>>
   userLoading: boolean;
   setUserLoading: React.Dispatch<React.SetStateAction<boolean>>
-  signOutUser: (hasExpoPushToken: boolean) => Promise<void>;
+  signOutUser: (deleteExpoPushToken: boolean) => Promise<void>;
 };
 
 export { UserContext, UserProvider };

--- a/src/helpers/pushNotification.ts
+++ b/src/helpers/pushNotification.ts
@@ -78,7 +78,7 @@ export const removeExpoPushToken = async () => {
   } catch (error) {
       console.error("Error removing token from Firestore: ", error);
   } finally {
-      await AsyncStorage.removeItem('@expoPushToken').catch((err) => console.error(err));
+      await AsyncStorage.removeItem('@expoPushToken').catch((err) => console.error("Issue removing expo push token locally: ", err));
   }
 }
 

--- a/src/helpers/pushNotification.ts
+++ b/src/helpers/pushNotification.ts
@@ -78,7 +78,7 @@ export const removeExpoPushToken = async () => {
   } catch (error) {
       console.error("Error removing token from Firestore: ", error);
   } finally {
-      await AsyncStorage.removeItem('@expoPushToken');
+      await AsyncStorage.removeItem('@expoPushToken').catch((err) => console.error(err));
   }
 }
 

--- a/src/screens/committees/Committees.tsx
+++ b/src/screens/committees/Committees.tsx
@@ -32,7 +32,7 @@ const Committees = ({ navigation }: NativeStackScreenProps<CommitteesStackParams
     const fetchUserData = async () => {
         console.log("Fetching user data...");
         try {
-            const firebaseUser = await getUser(auth.currentUser?.uid!);
+            const firebaseUser = await getUser(auth.currentUser?.uid!)
             if (firebaseUser) {
                 await AsyncStorage.setItem("@user", JSON.stringify(firebaseUser));
             }
@@ -41,12 +41,7 @@ const Committees = ({ navigation }: NativeStackScreenProps<CommitteesStackParams
             }
             setUserInfo(firebaseUser);
         } catch (error) {
-            if (error instanceof Error && error.message.includes("[AsyncStorage] Passing null/undefined as value is not supported.")) {
-                console.warn("User could not be obtained in Firebase. Data was likely deleted.");
-            }
-            else {
-                console.error("Error updating user:", error);
-            }
+            console.error("Error updating user:", error);
         }
     }
 

--- a/src/screens/committees/Committees.tsx
+++ b/src/screens/committees/Committees.tsx
@@ -32,11 +32,21 @@ const Committees = ({ navigation }: NativeStackScreenProps<CommitteesStackParams
     const fetchUserData = async () => {
         console.log("Fetching user data...");
         try {
-            const firebaseUser = await getUser(auth.currentUser?.uid!)
-            await AsyncStorage.setItem("@user", JSON.stringify(firebaseUser));
+            const firebaseUser = await getUser(auth.currentUser?.uid!);
+            if (firebaseUser) {
+                await AsyncStorage.setItem("@user", JSON.stringify(firebaseUser));
+            }
+            else {
+                console.warn("User data undefined. Data was likely deleted from Firebase.");
+            }
             setUserInfo(firebaseUser);
         } catch (error) {
-            console.error("Error updating user:", error);
+            if (error instanceof Error && error.message.includes("[AsyncStorage] Passing null/undefined as value is not supported.")) {
+                console.warn("User could not be obtained in Firebase. Data was likely deleted.");
+            }
+            else {
+                console.error("Error updating user:", error);
+            }
         }
     }
 

--- a/src/screens/resources/Resources.tsx
+++ b/src/screens/resources/Resources.tsx
@@ -25,7 +25,12 @@ const Resources = ({ navigation }: { navigation: NativeStackNavigationProp<Resou
         console.log("Fetching user data...");
         try {
             const firebaseUser = await getUser(auth.currentUser?.uid!)
-            await AsyncStorage.setItem("@user", JSON.stringify(firebaseUser));
+            if (firebaseUser) {
+                await AsyncStorage.setItem("@user", JSON.stringify(firebaseUser));
+            }
+            else {
+                console.warn("User data undefined. Data was likely deleted from Firebase.");
+            }
             setUserInfo(firebaseUser);
         } catch (error) {
             console.error("Error updating user:", error);

--- a/src/screens/userProfile/PublicProfile.tsx
+++ b/src/screens/userProfile/PublicProfile.tsx
@@ -56,7 +56,12 @@ const PublicProfileScreen: React.FC<PublicProfileScreenProps> = ({ route, naviga
     const fetchUserData = async () => {
         try {
             const firebaseUser = await getUser(auth.currentUser?.uid!)
-            await AsyncStorage.setItem("@user", JSON.stringify(firebaseUser));
+            if (firebaseUser) {
+                await AsyncStorage.setItem("@user", JSON.stringify(firebaseUser));
+            }
+            else {
+                console.warn("User data undefined. Data was likely deleted from Firebase.");
+            }
             setUserInfo(firebaseUser);
         } catch (error) {
             console.error("Error updating user:", error);

--- a/src/screens/userProfile/Settings.tsx
+++ b/src/screens/userProfile/Settings.tsx
@@ -92,7 +92,8 @@ const SettingsScreen = ({ navigation }: NativeStackScreenProps<HomeStackParams>)
             />
 
             <SettingsButton
-                mainText='Sign out'
+                mainText='Sign Out'
+                iconName='exit-to-app'
                 darkMode={darkMode}
                 onPress={() => signOutUser(true)}
             />


### PR DESCRIPTION
Simple patch to handling `AsyncStorage` when values come back as falsy from either `Firestore` or `AsyncStorage`. Also added more succinct messages to inform a developer what is happening.

### Changes
- For `signOutUser()`, the argument `hasExpoPushToken` has been renamed to `deleteExpoPushToken` to more closely reflect what the argument actually does
- Anytime a user is fetched, the user data is checked whether it is undefined. If it is, log a warning and set info as undefined
    - This also means the user will return to the login screen now when their data does not exist in Firestore.
- Error handling for removing an expo push token that doesn't exist (Though, I don't believe this was actually an issue. The app works as intended when I added it though, so it stays :P)
- Added icon to logout button in settings