### PR TITLE
Fixed issue with text being higher than it should on login screens

### DIFF
--- a/src/screens/onboarding/Login.tsx
+++ b/src/screens/onboarding/Login.tsx
@@ -14,7 +14,7 @@ const LoginScreen = ({ navigation }: NativeStackScreenProps<AuthStackParams>) =>
             className="flex-1"
         >
             <SafeAreaView className="flex-1">
-                <ScrollView>
+                <ScrollView contentContainerStyle={{ minHeight: "100%" }}>
                     {/* Header */}
                     <View className="items-center mt-12">
                         <Text className="text-white text-center text-4xl font-bold">Welcome to SHPE</Text>

--- a/src/screens/onboarding/LoginGuest.tsx
+++ b/src/screens/onboarding/LoginGuest.tsx
@@ -112,7 +112,7 @@ const LoginGuest = ({ navigation }: NativeStackScreenProps<AuthStackParams>) => 
         >
             <KeyboardAwareScrollView showsVerticalScrollIndicator={false} className="flex-1">
                 <SafeAreaView className="flex-1 h-screen">
-                    <ScrollView>
+                    <ScrollView contentContainerStyle={{ minHeight: "100%" }}>
                         {/* Header */}
                         <View className='px-4 mt-5'>
                             <TouchableOpacity

--- a/src/screens/onboarding/LoginStudent.tsx
+++ b/src/screens/onboarding/LoginStudent.tsx
@@ -114,7 +114,7 @@ const LoginStudent = ({ navigation }: NativeStackScreenProps<AuthStackParams>) =
         >
 
             <SafeAreaView className="flex-1">
-                <ScrollView>
+                <ScrollView contentContainerStyle={{ minHeight: "100%" }}>
                     {/* Header */}
                     <View className='px-4 mt-5'>
                         <TouchableOpacity


### PR DESCRIPTION
Fixed an issue I accidentally created where the lower text on the login screens doesn't render in the correct place. Now it is back to the bottom of the screen.

Please see if this looks okay on iPhone before merging