### PR TITLE
Hotfix: Random sign out

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "TAMU SHPE",
     "slug": "TAMU-SHPE",
-    "version": "1.0.12",
+    "version": "1.0.13",
     "owner": "tamu-shpe",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
@@ -54,7 +54,7 @@
       "permissions": [
         "android.permission.RECORD_AUDIO"
       ],
-      "versionCode": 76,
+      "versionCode": 78,
       "userInterfaceStyle": "automatic"
     },
     "ios": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shpe-app",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "scripts": {
     "start": "npx expo start --dev-client",
     "test": "jest --coverage=true --verbose --bail --config ./jest.config.ts",


### PR DESCRIPTION
### Overview
Remove fetch user in home screen causing random sign out.

When fetching the private data on the home screen. It possible to partially fetch the privateData. For example, we can fetch "expoPushToken" but the other fields will not be fetched. 
This important variable to be undefined.
The completedAccountSetupvariable forces users into the Auth Stack.


### Additional
As of right now it seem to only be a problem when u reload the app and not in other screen. So i'm assuming this is a problem with auth not loading fast enough (but again we're able to fetch expoPushToken so idk)
