### PR TITLE
Point calculation fix

### DIFF
--- a/functions/src/events.ts
+++ b/functions/src/events.ts
@@ -68,26 +68,24 @@ const calculateEventLogPoints = (event: SHPEEvent, log: SHPEEventLog): number =>
     }
 
     let hourlyPoints = 0;
-    switch (event.eventType) {
-        case EventType.CUSTOM_EVENT:
-        case EventType.STUDY_HOURS:
-            if (log.signInTime && log.signOutTime && log.signInTime.toMillis() < log.signOutTime.toMillis()) {
-                hourlyPoints = (log.signOutTime.toMillis() - log.signInTime.toMillis()) / MillisecondTimes.HOUR * (event.pointsPerHour ?? 0);
-            }
+    if (event.pointsPerHour) {
+        switch (event.eventType) {
+            case EventType.VOLUNTEER_EVENT:
+                if (log.signInTime && log.signOutTime && log.signInTime.toMillis() < log.signOutTime.toMillis()) {
+                    hourlyPoints = Math.round((log.signOutTime.toMillis() - log.signInTime.toMillis()) / MillisecondTimes.HOUR) * (event.pointsPerHour ?? 0);
+                }
+                break;
+            default:
+                if (log.signInTime && log.signOutTime && log.signInTime.toMillis() < log.signOutTime.toMillis()) {
+                    hourlyPoints = (log.signOutTime.toMillis() - log.signInTime.toMillis()) / MillisecondTimes.HOUR * (event.pointsPerHour ?? 0);
+                }
 
-            if (event.endTime && event.startTime) {
-                const eventDurationHours = (event.endTime.toMillis() - event.startTime.toMillis()) / MillisecondTimes.HOUR;
-                hourlyPoints = Math.min(eventDurationHours * (event.pointsPerHour ?? 0), hourlyPoints);
-            }
-            break;
-        case EventType.VOLUNTEER_EVENT:
-            if (log.signInTime && log.signOutTime && log.signInTime.toMillis() < log.signOutTime.toMillis()) {
-                hourlyPoints = Math.round((log.signOutTime.toMillis() - log.signInTime.toMillis()) / MillisecondTimes.HOUR) * (event.pointsPerHour ?? 0);
-            }
-            log.points = (log.points ?? 0) + (event.signOutPoints ?? 0) + hourlyPoints;
-            break;
-        default:
-            hourlyPoints = 0;
+                if (event.endTime && event.startTime) {
+                    const eventDurationHours = (event.endTime.toMillis() - event.startTime.toMillis()) / MillisecondTimes.HOUR;
+                    hourlyPoints = Math.min(eventDurationHours * (event.pointsPerHour ?? 0), hourlyPoints);
+                }
+                break;
+        }
     }
 
     totalPoints += hourlyPoints;

--- a/functions/src/events.ts
+++ b/functions/src/events.ts
@@ -246,7 +246,7 @@ export const eventSignOut = functions.https.onCall(async (data, context) => {
     // Sets log in both event and user collection and ensures both happen by the end of the function. 
     await eventLogDocRef.set(eventLog, { merge: true });
     await db.collection(`users/${uid}/event-logs`).doc(data.eventID).set(eventLog, { merge: true });
-    functions.logger.log(`User ${uid} successfully signed in and earned ${eventLog.points} points`);
+    functions.logger.log(`User ${uid} successfully signed out and earned ${eventLog.points} points`);
 
     return { success: true };
 });


### PR DESCRIPTION
Minor bug fix:

- Removed accidental side-effect of modifying the passed in `log` object for `calculateEventLogPoints`
- Changed log text to be "signed out" for `eventSignOut`
- All events are now support `pointsPerHour`
    - Even if this isn't really going to be used. It just makes the code more predictable

This is not related to any issue. It's just some tweaks I noticed needed to be made.