### PR TITLE
Updated node version in workflow

### DIFF
--- a/.github/workflows/CITests.yml
+++ b/.github/workflows/CITests.yml
@@ -13,7 +13,7 @@ jobs:
 
         strategy:
             matrix:
-                node-version: [ 18.x ]
+                node-version: [ 20.x ]
                 java-version: [ 21 ]
 
         steps:


### PR DESCRIPTION
Node v18 has reached end of life, so this updates the version for unit tests to a more recent version.

https://nodejs.org/en/about/previous-releases

This also addresses the most recent CI/CD fail in main: https://github.com/TAMUSHPE/MobileApp/actions/runs/16037440919/job/45252284086