### PR TITLE
Remove the private resume upload from profile and onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,12 +148,17 @@ $ docker compose up          # or: yarn emulators
 | Firestore    | `localhost:8080`        |
 | Auth         | `localhost:9099`        |
 
-Two accounts are seeded automatically, both with the password `password123`:
+Three accounts are seeded automatically, all with the password `password123`:
 
-| Email               | Purpose                                                      |
-| ------------------- | ------------------------------------------------------------ |
-| `member@tamu.edu`   | Has **no** `gender` field, so the gender prompt appears       |
-| `officer@tamu.edu`  | Already answered the gender question, and has officer roles   |
+| Email                 | Purpose                                                       |
+| --------------------- | ------------------------------------------------------------- |
+| `member@tamu.edu`     | Has **no** `gender` field, so the gender prompt appears        |
+| `officer@tamu.edu`    | Already answered the gender question, and has officer roles    |
+| `newmember@tamu.edu`  | Has `completedAccountSetup: false`, so it lands in onboarding  |
+
+Signing in as `newmember@tamu.edu` is the way to walk the profile setup flow without
+registering a throwaway account against production. Completing the flow sets the flag
+to `true` and spends the fixture — `yarn emulators:reset` brings it back.
 
 ### Pointing the app at it
 

--- a/firebase-emulator/seed.js
+++ b/firebase-emulator/seed.js
@@ -25,10 +25,19 @@ const auth = admin.auth();
 /**
  * Fixtures mirror the shapes in src/types/user.ts. `gender` lives on privateInfo.
  *
- * Two users exist on purpose: one already answered the gender question and one has
- * never been asked. The second is what GenderPromptModal keys off — it shows only
- * when privateInfo.gender is `undefined` — so signing in as that account is the way
- * to exercise the prompt locally.
+ * Three users exist on purpose:
+ *
+ *   - `member@tamu.edu` finished setup but has never been asked the gender question.
+ *     GenderPromptModal keys off exactly that — it shows only when privateInfo.gender
+ *     is `undefined` — so this is the account for exercising the prompt.
+ *   - `officer@tamu.edu` has answered it, and carries officer roles.
+ *   - `newmember@tamu.edu` has `completedAccountSetup: false`, which is the flag
+ *     src/navigation/index.tsx branches on to route into ProfileSetupStack. Signing
+ *     in as this account drops straight into onboarding, so the flow can be walked
+ *     without registering a throwaway user or hand-editing the flag each time.
+ *
+ * Note that finishing onboarding sets completedAccountSetup to true, spending the
+ * fixture. `yarn emulators:reset` restores it.
  */
 const USERS = [
     {
@@ -75,6 +84,25 @@ const USERS = [
             gender: "Prefer not to say",
         },
     },
+    {
+        uid: "seed-member-onboarding",
+        email: "newmember@tamu.edu",
+        displayName: "Seed New Member",
+        // Deliberately sparse: this mirrors what initializeCurrentUserData() writes at
+        // registration, before any setup screen has run. Name, bio, major, class year
+        // and interests are all absent because onboarding is what fills them in.
+        publicInfo: {
+            roles: { reader: true },
+            points: 0,
+            pointsThisMonth: 0,
+            isEmailPublic: false,
+        },
+        privateInfo: {
+            completedAccountSetup: false,
+            settings: { darkMode: false, useSystemDefault: true },
+            // No `gender` key: onboarding collects it partway through the flow.
+        },
+    },
 ];
 
 const seedUser = async (user) => {
@@ -99,7 +127,8 @@ const seedUser = async (user) => {
     );
     await db.doc(`users/${user.uid}/private/privateInfo`).set(user.privateInfo, { merge: true });
 
-    console.log(`  ${user.email} (${user.uid}) — gender: ${user.privateInfo.gender ?? "not set"}`);
+    const setupState = user.privateInfo.completedAccountSetup ? "complete" : "not started";
+    console.log(`  ${user.email} (${user.uid}) — setup: ${setupState}, gender: ${user.privateInfo.gender ?? "not set"}`);
 };
 
 const main = async () => {

--- a/src/navigation/ProfileSetupStack.tsx
+++ b/src/navigation/ProfileSetupStack.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { createStackNavigator } from '@react-navigation/stack';
 import { ProfileSetupStackParams } from "../types/navigation";
-import { SetupNameAndBio, SetupProfilePicture, SetupAcademicInformation, SetupGender, SetupResume, SetupInterests } from "../screens/onboarding/ProfileSetup";
+import { SetupNameAndBio, SetupProfilePicture, SetupAcademicInformation, SetupGender, SetupInterests } from "../screens/onboarding/ProfileSetup";
 import LoginScreen from "../screens/onboarding/Login";
 
 
@@ -15,7 +15,6 @@ const ProfileSetupStack = () => {
             <Stack.Screen name="SetupAcademicInformation" component={SetupAcademicInformation} />
             <Stack.Screen name="SetupGender" component={SetupGender} />
             <Stack.Screen name="SetupInterests" component={SetupInterests} />
-            <Stack.Screen name="SetupResume" component={SetupResume} />
             <Stack.Screen name="LoginScreen" component={LoginScreen} />
         </Stack.Navigator>
     );

--- a/src/screens/onboarding/ProfileSetup.tsx
+++ b/src/screens/onboarding/ProfileSetup.tsx
@@ -5,19 +5,15 @@ import * as ImagePicker from "expo-image-picker";
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Octicons } from '@expo/vector-icons';
-import { Circle, Svg } from 'react-native-svg';
 import { UserContext } from '../../context/UserContext';
 import { auth } from '../../config/firebaseConfig';
 import { getUser, setPrivateUserData, setPublicUserData, uploadFile } from '../../api/firebaseUtils';
-import { getBlobFromURI, selectFile, selectImage } from '../../api/fileSelection';
+import { getBlobFromURI, selectImage } from '../../api/fileSelection';
 import { updateProfile } from 'firebase/auth';
 import { CommonMimeTypes, validateName } from '../../helpers/validation';
-import { handleLinkPress } from '../../helpers/links';
 import { MAJORS, classYears, GENDER_OPTIONS } from '../../types/user';
 import { ProfileSetupStackParams } from '../../types/navigation';
 import { Images } from '../../../assets';
-import UploadFileIcon from '../../../assets/file-arrow-up-solid.svg';
-import DownloadIcon from '../../../assets/arrow-down-solid_white.svg';
 import IntramuralIcon from '../../../assets/intramural_white.svg';
 import SocialIcon from '../../../assets/social_white.svg';
 import StudyHoursIcon from '../../../assets/study_hour_white.svg';
@@ -31,7 +27,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 
 const safeAreaViewStyle = "flex-1 justify-between bg-dark-navy py-10 px-8";
 
-const TOTAL_SETUP_STEPS = 6;
+const TOTAL_SETUP_STEPS = 5;
 
 /**
  * The row of dashes at the top of every profile-setup screen, filled in up to the current step.
@@ -490,7 +486,7 @@ const SetupGender = ({ navigation }: NativeStackScreenProps<ProfileSetupStackPar
                                     if (auth.currentUser) {
                                         await setPrivateUserData({ gender: gender });
                                     }
-                                    navigation.navigate("SetupResume");
+                                    navigation.navigate("SetupInterests");
                                 } catch (err) {
                                     console.error("Error saving gender:", err);
                                     setError("Could not save. Check your connection and try again.");
@@ -514,170 +510,6 @@ const SetupGender = ({ navigation }: NativeStackScreenProps<ProfileSetupStackPar
         </LinearGradient>
     );
 };
-
-const SetupResume = ({ navigation }: NativeStackScreenProps<ProfileSetupStackParams>) => {
-    const [resumeURL, setResumeURL] = useState<string | null>(null);
-    const [loading, setLoading] = useState<boolean>(false);
-    const [resumeName, setResumeName] = useState<string | null>(null);
-
-    const progress = useRef(new Animated.Value(0)).current;
-    const setProgress = (newProgress: number) => {
-        if (newProgress <= 0) {
-            progress.setValue(0);
-        } else if (newProgress >= 100) {
-            progress.setValue(100);
-        } else {
-            Animated.timing(progress, {
-                toValue: newProgress,
-                duration: 500,
-                useNativeDriver: true,
-            }).start();
-        }
-    };
-
-    const AnimatedCircle = Animated.createAnimatedComponent(Circle);
-    const circumference = 2 * Math.PI * 45; // 45 is the radius of the circle
-    const strokeDashoffset = progress.interpolate({
-        inputRange: [0, 100],
-        outputRange: [circumference, 0]
-    });
-
-    const selectResume = async () => {
-        const result = await selectFile();
-        if (result) {
-            const resumeBlob = await getBlobFromURI(result.assets![0].uri);
-            setResumeName(result.assets![0].name);
-            return resumeBlob;
-        }
-
-        return null;
-    }
-
-    const onResumeUploadSuccess = async (URL: string) => {
-        console.log("File available at", URL);
-        if (auth.currentUser) {
-            setResumeURL(URL);
-            await setPrivateUserData({
-                resumeURL: URL
-            });
-        }
-        setLoading(false);
-    }
-
-
-    return (
-        <LinearGradient
-            colors={['#191740', '#413CA6']}
-            className="flex-1"
-        >
-            <SafeAreaView className='flex-1'>
-                <ScrollView>
-
-                    {/* Header */}
-                    <View className='px-4 mt-5 flex-row items-center'>
-                        <TouchableOpacity
-                            onPress={() => navigation.goBack()}
-                            activeOpacity={1}
-                        >
-                            <Octicons name="chevron-left" size={30} color="white" />
-                        </TouchableOpacity>
-
-                        <ProgressDashes step={5} />
-                    </View>
-
-                    <View className='mx-8 mt-8'>
-                        <Text className='text-white text-3xl font-bold'>Professional Information</Text>
-                        <Text className='text-white text-xl mt-2'>Your resume will be sent to companies for various opportunities. This can be changed later.</Text>
-                    </View>
-
-
-                    <View className="mx-8 mt-4">
-                        <View className='items-center'>
-                            {resumeURL && (
-                                <TouchableOpacity
-                                    onPress={async () => { handleLinkPress(resumeURL!) }}
-                                >
-                                    <View className='relative flex-row items-center border-b border-white'>
-                                        <Text className="text-white font-semibold text-lg">{resumeName}</Text>
-                                        <View className='absolute left-full ml-1'>
-                                            <DownloadIcon width={15} height={15} />
-                                        </View>
-                                    </View>
-                                </TouchableOpacity>
-                            )}
-                            <TouchableOpacity className="relative items-center justify-center rounded-full h-44 w-44 mb-10 mt-4"
-                                onPress={async () => {
-                                    const selectedResume = await selectResume();
-                                    if (selectedResume) {
-                                        uploadFile(
-                                            selectedResume,
-                                            CommonMimeTypes.RESUME_FILES,
-                                            `user-docs/${auth.currentUser?.uid}/user-resume`,
-                                            onResumeUploadSuccess,
-                                            setProgress
-                                        );
-                                    }
-                                }}>
-                                <Svg height="100%" width="100%" viewBox="0 0 100 100" className="absolute">
-                                    <Circle
-                                        cx="50"
-                                        cy="50"
-                                        r="45"
-                                        stroke="#ffffff"
-                                        strokeWidth="4"
-                                        fill="transparent"
-                                    />
-                                </Svg>
-                                <Svg height="100%" width="100%" viewBox="0 0 100 100" className="absolute">
-                                    <AnimatedCircle
-                                        cx="50"
-                                        cy="50"
-                                        r="45"
-                                        stroke="#AEF359"
-                                        strokeWidth="4"
-                                        fill="transparent"
-                                        strokeDasharray={circumference}
-                                        strokeDashoffset={strokeDashoffset}
-                                        transform="rotate(-90, 50, 50)"
-                                    />
-                                </Svg>
-                                <UploadFileIcon width={110} height={110} />
-                                <View className='h-full w-full absolute top-10 left-14'>
-                                    <Text className='text-black font-extrabold text-xl'>pdf</Text>
-                                </View>
-                            </TouchableOpacity>
-
-                            {loading && (
-                                <ActivityIndicator className="mb-4" size={"small"} />
-                            )}
-
-                        </View>
-                        <InteractButton
-                            onPress={() => {
-                                if (resumeURL) {
-                                    navigation.navigate("SetupInterests")
-                                }
-                            }}
-                            label='Continue'
-                            opacity={!resumeURL ? 1 : 0.8}
-                            buttonClassName={`justify-center items-center rounded-xl h-14 ${!resumeURL ? "bg-grey-dark" : "bg-primary-orange"}`}
-                            textClassName={`text-white font-semibold text-2xl text-white`}
-                            underlayColor={`${!resumeURL ? "" : "#EF9260"}`}
-                        />
-
-                        <InteractButton
-                            onPress={() => navigation.navigate("SetupInterests")}
-                            label='Skip For Now'
-                            buttonClassName='justify-center items-center mt-4'
-                            textClassName='text-primary-orange text-xl font-semibold'
-                            underlayColor='transparent'
-                        />
-                    </View>
-                </ScrollView>
-            </SafeAreaView>
-        </LinearGradient>
-    )
-}
 
 /**
  * This screen is where the user will choose which committees they're in, if any. The user can select committees, 
@@ -752,7 +584,7 @@ const SetupInterests = ({ navigation }: NativeStackScreenProps<ProfileSetupStack
                             <Octicons name="chevron-left" size={30} color="white" />
                         </TouchableOpacity>
 
-                        <ProgressDashes step={6} />
+                        <ProgressDashes step={5} />
                     </View>
 
                     <View className='mx-8 mt-8'>
@@ -829,4 +661,4 @@ const SetupInterests = ({ navigation }: NativeStackScreenProps<ProfileSetupStack
     );
 };
 
-export { SetupNameAndBio, SetupProfilePicture, SetupAcademicInformation, SetupGender, SetupResume, SetupInterests };
+export { SetupNameAndBio, SetupProfilePicture, SetupAcademicInformation, SetupGender, SetupInterests };

--- a/src/screens/userProfile/Settings.tsx
+++ b/src/screens/userProfile/Settings.tsx
@@ -1,5 +1,5 @@
-import { View, Text, Image, ScrollView, TextInput, TouchableHighlight, TouchableOpacity, ActivityIndicator, KeyboardAvoidingView, Platform, Alert, Pressable, Animated, useColorScheme } from 'react-native';
-import React, { useContext, useEffect, useRef, useState } from 'react';
+import { View, Text, Image, ScrollView, TextInput, TouchableHighlight, TouchableOpacity, ActivityIndicator, KeyboardAvoidingView, Platform, Alert, Pressable, useColorScheme } from 'react-native';
+import React, { useContext, useEffect, useState } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { MaterialCommunityIcons } from '@expo/vector-icons'
@@ -10,21 +10,16 @@ import { UserContext } from '../../context/UserContext';
 import { auth } from '../../config/firebaseConfig';
 import { sendPasswordResetEmail, updateProfile } from 'firebase/auth';
 import { setPublicUserData, setPrivateUserData, getUser, getCommittees, submitFeedback, isUsernameUnique, deleteAccount, uploadFile } from '../../api/firebaseUtils';
-import { getBlobFromURI, selectFile, selectImage } from '../../api/fileSelection';
+import { getBlobFromURI, selectImage } from '../../api/fileSelection';
 import { CommonMimeTypes, validateDisplayName, validateFileBlob, validateName, validateTamuEmail } from '../../helpers/validation';
 import { handleLinkPress } from '../../helpers/links';
 import { HomeStackParams } from '../../types/navigation';
 import { Committee } from '../../types/committees';
 import { MAJORS, classYears } from '../../types/user';
 import { Images } from '../../../assets';
-import DownloadIconBlack from '../../../assets/arrow-down-solid.svg';
-import DownloadIconWhite from '../../../assets/arrow-down-solid_white.svg'
-import UploadFileIconBlack from '../../../assets/file-arrow-up-solid-black.svg';
-import UploadFileIconWhite from '../../../assets/file-arrow-up-solid.svg'
 
 import { SettingsSectionTitle, SettingsButton, SettingsToggleButton, SettingsListItem, SettingsSaveButton, SettingsModal } from "../../components/SettingsComponents"
 import CustomDropDown from '../../components/CustomDropDown';
-import { Circle, Svg } from 'react-native-svg';
 import DismissibleModal from '../../components/DismissibleModal';
 import * as Clipboard from 'expo-clipboard';
 
@@ -125,7 +120,6 @@ const ProfileSettingsScreen = ({ navigation }: NativeStackScreenProps<HomeStackP
 
     //Hooks used to save state of modified fields before user hits "save"
     const [photoURL, setPhotoURL] = useState<string | undefined>(userInfo?.publicInfo?.photoURL);
-    const [resumeURL, setResumeURL] = useState<string | undefined>(userInfo?.private?.privateInfo?.resumeURL);
     const [displayName, setDisplayName] = useState<string | undefined>(userInfo?.publicInfo?.displayName);
     const [name, setName] = useState<string | undefined>(userInfo?.publicInfo?.name);
     const [bio, setBio] = useState<string | undefined>(userInfo?.publicInfo?.bio);
@@ -141,7 +135,6 @@ const ProfileSettingsScreen = ({ navigation }: NativeStackScreenProps<HomeStackP
     const [showNamesModal, setShowNamesModal] = useState<boolean>(false);
     const [showBioModal, setShowBioModal] = useState<boolean>(false);
     const [showAcademicInfoModal, setShowAcademicInfoModal] = useState<boolean>(false);
-    const [showResumeModal, setShowResumeModal] = useState<boolean>(false);
 
     useEffect(() => {
         const fetchCommitteeData = async () => {
@@ -188,15 +181,6 @@ const ProfileSettingsScreen = ({ navigation }: NativeStackScreenProps<HomeStackP
         });
     }
 
-    const selectResume = async () => {
-        const result = await selectFile();
-        if (result) {
-            const resumeBlob = await getBlobFromURI(result.assets![0].uri);
-            return resumeBlob;
-        }
-        return null
-    }
-
     const onProfilePictureUploadSuccess = async (URL: string) => {
         console.log("File available at", URL);
         if (auth.currentUser) {
@@ -218,17 +202,6 @@ const ProfileSettingsScreen = ({ navigation }: NativeStackScreenProps<HomeStackP
             setOpenDropdown(dropdownKey);
         }
     };
-
-    const onResumeUploadSuccess = async (URL: string) => {
-        console.log("File available at", URL);
-        if (auth.currentUser) {
-            setResumeURL(URL);
-            await setPrivateUserData({
-                resumeURL: URL
-            });
-        }
-
-    }
 
     const saveChanges = async () => {
         setLoading(true)
@@ -282,39 +255,12 @@ const ProfileSettingsScreen = ({ navigation }: NativeStackScreenProps<HomeStackP
                 setLoading(false);
                 setShowSaveButton(false);
             });
-
-        setPrivateUserData({
-            ...(resumeURL !== undefined) && { resumeURL: resumeURL },
-        })
     }
 
     const findMajorByIso = (iso: string) => {
         const majorObj = MAJORS.find(major => major.iso === iso);
         return majorObj ? majorObj.major : null;
     };
-
-    const progress = useRef(new Animated.Value(0)).current;
-    const setProgress = (newProgress: number) => {
-        if (newProgress <= 0) {
-            progress.setValue(0);
-        } else if (newProgress >= 100) {
-            progress.setValue(100);
-        } else {
-            Animated.timing(progress, {
-                toValue: newProgress,
-                duration: 500,
-                useNativeDriver: true,
-            }).start();
-        }
-    };
-
-    const AnimatedCircle = Animated.createAnimatedComponent(Circle);
-    const circumference = 2 * Math.PI * 45; // 45 is the radius of the circle
-    const strokeDashoffset = progress.interpolate({
-        inputRange: [0, 100],
-        outputRange: [circumference, 0]
-    });
-
 
     return (
         <View className='items-center'>
@@ -463,68 +409,6 @@ const ProfileSettingsScreen = ({ navigation }: NativeStackScreenProps<HomeStackP
                 }
             />
 
-            {/* Resume Modal */}
-            <SettingsModal
-                visible={showResumeModal}
-                onCancel={() => setShowResumeModal(false)}
-                onDone={() => setShowResumeModal(false)}
-                darkMode={darkMode}
-                content={(
-                    <View>
-                        <View className='items-center'>
-                            <TouchableOpacity className="relative items-center justify-center rounded-full h-44 w-44 mb-5 mt-4"
-                                onPress={async () => {
-                                    const selectedResume = await selectResume();
-                                    if (selectedResume) {
-                                        uploadFile(
-                                            selectedResume,
-                                            CommonMimeTypes.RESUME_FILES,
-                                            `user-docs/${auth.currentUser?.uid}/user-resume`,
-                                            onResumeUploadSuccess,
-                                            setProgress
-                                        );
-                                    }
-                                }}>
-                                <Svg height="100%" width="100%" viewBox="0 0 100 100" className="absolute">
-                                    <Circle
-                                        cx="50"
-                                        cy="50"
-                                        r="45"
-                                        stroke={darkMode ? "#a3a3a3" : "#000000"}
-                                        strokeWidth="3"
-                                        fill="transparent"
-                                    />
-                                </Svg>
-                                <Svg height="100%" width="100%" viewBox="0 0 100 100" className="absolute">
-                                    <AnimatedCircle
-                                        cx="50"
-                                        cy="50"
-                                        r="45"
-                                        stroke="#AEF359"
-                                        strokeWidth="4"
-                                        fill="transparent"
-                                        strokeDasharray={circumference}
-                                        strokeDashoffset={strokeDashoffset}
-                                        transform="rotate(-90, 50, 50)"
-                                    />
-                                </Svg>
-                                {darkMode ? <UploadFileIconWhite width={110} height={110} /> : <UploadFileIconBlack width={110} height={110} />}
-                            </TouchableOpacity>
-
-                            {resumeURL && (
-                                <TouchableOpacity onPress={async () => { handleLinkPress(resumeURL!) }}>
-                                    <View className={`relative flex-row items-center border-b ${darkMode ? "border-white" : "border-black"}`}>
-                                        <Text className={`font-semibold text-lg ${darkMode ? "text-white" : "text-black"}`}>View Resume</Text>
-                                        <View className='absolute left-full ml-1'>
-                                            {darkMode ? <DownloadIconWhite width={15} height={15} /> : <DownloadIconBlack width={15} height={15} />}
-                                        </View>
-                                    </View>
-                                </TouchableOpacity>
-                            )}
-                        </View>
-                    </View>
-                )}
-            />
             <ScrollView className={`flex-col w-full pb-10 ${darkMode ? "bg-primary-bg-dark" : "bg-primary-bg-light"}`}>
                 <View className='py-10 w-full items-center'>
                     <TouchableOpacity activeOpacity={0.7} onPress={async () => await selectProfilePicture()}>
@@ -568,13 +452,6 @@ const ProfileSettingsScreen = ({ navigation }: NativeStackScreenProps<HomeStackP
                     subText={classYear ?? defaultVals.classYear}
                     darkMode={darkMode}
                     onPress={() => setShowAcademicInfoModal(true)}
-                />
-                <SettingsSectionTitle text='SHPE Info' darkMode={darkMode} />
-                <SettingsButton
-                    mainText='Resume'
-                    subText='Keep your resume updated!'
-                    darkMode={darkMode}
-                    onPress={() => setShowResumeModal(true)}
                 />
                 <View className='h-20' />
                 {loading && <ActivityIndicator className='absolute top-0 bottom-0 left-0 right-0' size={100} />}

--- a/src/types/navigation.ts
+++ b/src/types/navigation.ts
@@ -23,7 +23,6 @@ export type ProfileSetupStackParams = {
     SetupAcademicInformation: undefined;
     SetupGender: undefined;
     SetupInterests: undefined;
-    SetupResume: undefined;
     MainStack: undefined;
 }
 

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -67,7 +67,6 @@ export interface PrivateUserInfo {
     settings?: AppSettings;
     expoPushTokens?: string[];
     expirationDate?: Timestamp;
-    resumeURL?: string;
     email?: string;
     /** One of GENDER_OPTIONS. Undefined means the user has not answered yet. */
     gender?: string;


### PR DESCRIPTION
## What this does

Removes the private resume feature: the file users uploaded from **Settings → SHPE Info → Resume**, and the matching step in onboarding.

That resume was stored on `privateInfo.resumeURL` and uploaded to `user-docs/{uid}/user-resume`. It had no consumers — nothing read it back, no admin screen surfaced it, no export used it. It was write-only.

## The resume bank is not affected

Worth stating plainly, since the names are similar. The public resume bank is a separate system and is untouched:

|  | Removed | Kept |
|---|---|---|
| Firestore | `privateInfo.resumeURL` | `publicInfo.resumePublicURL`, `resumeVerified` |
| Storage path | `user-docs/{uid}/user-resume` | `user-docs/{uid}/user-resume-public` |
| Written by | Settings, onboarding | `ResumeSubmit` |

No files under `screens/resources/` or `screens/admin/` were modified, and `firebaseUtils.ts` is unchanged. `CommonMimeTypes.RESUME_FILES` stays, since `ResumeSubmit` still uses it.

## Notable changes

- **Settings** loses the entire "SHPE Info" section, not just the Resume row — that row was the section's only entry, so the header would have rendered empty.
- **Onboarding drops from 6 steps to 5.** `SetupGender` now continues straight to `SetupInterests`, and `TOTAL_SETUP_STEPS` is 5 so the progress dashes stay in sync. This is the change most worth a careful look.

## Emulator fixture

The second commit adds `newmember@tamu.edu` to the emulator seed, with `completedAccountSetup: false`. Both existing fixtures have it set to `true`, so neither routes into `ProfileSetupStack` — testing onboarding previously meant registering a throwaway account against production or hand-editing the flag each run. Completing the flow spends the fixture; `yarn emulators:reset` restores it.

## Testing

Verified on an Android emulator against the Firebase emulator suite:

- Onboarding runs 5 steps, Gender → Interests, no resume screen, 5 progress dashes
- Settings ends at Academic Info with no SHPE Info section
- Resume bank still opens and accepts an upload

`tsc --noEmit` reports no new errors in the touched files.
