### PR TITLE
Fix committee leadership member removal

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -1,0 +1,41 @@
+module.exports = ({ config }) => {
+  // Deliberately NOT the same key as GOOGLE_PLACES_API_KEY. This one is consumed by the Maps SDK
+  // for Android, which sends X-Android-Package / X-Android-Cert headers, so it can carry an
+  // "Android apps" restriction (package com.tamu.shpe + the release and debug SHA-1s) and is
+  // useless to anyone who extracts it from the APK.
+  // The Places and Geocoding calls in src/helpers/geolocationUtils.ts are plain fetches against the
+  // web service, send no such headers, and would be rejected by that restriction — hence two keys.
+  const googleMapsApiKey = process.env.GOOGLE_MAPS_API_KEY;
+
+  if (!googleMapsApiKey) {
+    // The EAS variable is stored with SECRET visibility, so it resolves only on the build worker,
+    // never on a developer machine. The Android manifest is written during prebuild on that worker,
+    // so a local config evaluation (versionCode/runtimeVersion resolution for eas build, plus
+    // expo start, eas update, eas env:list) has no need for the key — only a real build does.
+    if (process.env.EAS_BUILD) {
+      throw new Error(
+        'Missing GOOGLE_MAPS_API_KEY on the EAS build worker. Add it to this build profile\'s ' +
+          'environment (it is the Android-app-restricted Maps SDK key, separate from GOOGLE_PLACES_API_KEY).'
+      );
+    }
+    console.warn(
+      '[app.config] GOOGLE_MAPS_API_KEY not set — Android maps will not render in a local build. ' +
+        'Set it in .env if you are running expo prebuild / run:android.'
+    );
+    return config;
+  }
+
+  return {
+    ...config,
+    android: {
+      ...config.android,
+      config: {
+        ...config.android?.config,
+        googleMaps: {
+          ...config.android?.config?.googleMaps,
+          apiKey: googleMapsApiKey,
+        },
+      },
+    },
+  };
+};

--- a/app.json
+++ b/app.json
@@ -80,12 +80,7 @@
         "android.permission.ACCESS_FINE_LOCATION"
       ],
       "versionCode": 161,
-      "userInterfaceStyle": "automatic",
-      "config": {
-        "googleMaps": {
-          "apiKey": "AIzaSyB1aZFHZCIN0RdvpzfWQflkHpiyGd2Qfo8"
-        }
-      }
+      "userInterfaceStyle": "automatic"
     },
     "ios": {
       "bundleIdentifier": "com.tamu.shpe",

--- a/eas.json
+++ b/eas.json
@@ -6,67 +6,41 @@
   "build": {
     "development": {
       "distribution": "internal",
+      "environment": "development",
       "android": {
-        "gradleCommand": ":app:assembleDebug",
-        "env": {
-          "GOOGLE_SERVICES_JSON": "GOOGLE_SERVICES_JSON",
-          "FLICKER_API_KEY": "FLICKER_API_KEY",
-          "FLICKER_USER_ID": "FLICKER_USER_ID",
-          "GOOGLE_PLACES_API_KEY": "GOOGLE_PLACES_API_KEY",
-          "GOOGLE_API_KEY": "GOOGLE_API_KEY"
-        }
+        "gradleCommand": ":app:assembleDebug"
       },
       "ios": {
-        "buildConfiguration": "Debug",
-        "env": {
-          "GOOGLE_SERVICE_INFO_PLIST": "GOOGLE_SERVICE_INFO_PLIST",
-          "FLICKER_API_KEY": "FLICKER_API_KEY",
-          "FLICKER_USER_ID": "FLICKER_USER_ID",
-          "GOOGLE_PLACES_API_KEY": "GOOGLE_PLACES_API_KEY",
-          "GOOGLE_API_KEY": "GOOGLE_API_KEY"
-        }
+        "buildConfiguration": "Debug"
       },
       "channel": "development"
     },
     "preview": {
       "distribution": "internal",
+      "environment": "preview",
       "channel": "staging"
+    },
+    "member-apk": {
+      "distribution": "internal",
+      "channel": "production",
+      "environment": "production",
+      "android": {
+        "buildType": "apk"
+      }
     },
     "production": {
       "autoIncrement": true,
       "channel": "production",
-      "env": {
-        "GOOGLE_SERVICES_JSON": "GOOGLE_SERVICES_JSON",
-        "GOOGLE_SERVICE_INFO_PLIST": "GOOGLE_SERVICE_INFO_PLIST",
-        "FLICKER_API_KEY": "FLICKER_API_KEY",
-        "FLICKER_USER_ID": "FLICKER_USER_ID",
-        "GOOGLE_PLACES_API_KEY": "GOOGLE_PLACES_API_KEY",
-        "GOOGLE_API_KEY": "GOOGLE_API_KEY"
-      }
+      "environment": "production"
     },
     "development-sim": {
       "distribution": "internal",
       "developmentClient": true,
+      "environment": "development",
       "ios": {
         "simulator": false,
         "image": "latest",
-        "resourceClass": "m-medium",
-        "env": {
-          "GOOGLE_SERVICE_INFO_PLIST": "GOOGLE_SERVICE_INFO_PLIST",
-          "FLICKER_API_KEY": "FLICKER_API_KEY",
-          "FLICKER_USER_ID": "FLICKER_USER_ID",
-          "GOOGLE_PLACES_API_KEY": "GOOGLE_PLACES_API_KEY",
-          "GOOGLE_API_KEY": "GOOGLE_API_KEY"
-        }
-      },
-      "android": {
-        "env": {
-          "GOOGLE_SERVICES_JSON": "GOOGLE_SERVICES_JSON",
-          "FLICKER_API_KEY": "FLICKER_API_KEY",
-          "FLICKER_USER_ID": "FLICKER_USER_ID",
-          "GOOGLE_PLACES_API_KEY": "GOOGLE_PLACES_API_KEY",
-          "GOOGLE_API_KEY": "GOOGLE_API_KEY"
-        }
+        "resourceClass": "m-medium"
       }
     }
   },

--- a/src/api/__tests__/firebaseUtils.test.ts
+++ b/src/api/__tests__/firebaseUtils.test.ts
@@ -7,6 +7,7 @@ import { doc, setDoc, deleteDoc, getDoc, Timestamp, serverTimestamp, DocumentDat
 import { EventType, SHPEEvent, SHPEEventLog } from "../../types/events";
 import { Committee } from "../../types/committees";
 import { LinkData } from "../../types/links";
+import { removeCommitteeMemberUid } from "../../helpers/committeeMembers";
 
 const testUserDataList: User[] = require("./test_data/users.json");
 const testEvents = require('./test_data/events.json');
@@ -111,6 +112,20 @@ describe("User Info", () => {
         await deleteDoc(doc(db, "users", auth.currentUser?.uid!));
         await deleteDoc(doc(db, `users/${auth.currentUser?.uid!}/private`, "privateInfo"));
 
+    });
+
+    test('getPublicUserData uses the Firestore document ID as the canonical uid', async () => {
+        const userDocRef = doc(db, 'users', 'canonical-user-id');
+
+        try {
+            await setDoc(userDocRef, { name: 'User without a stored UID' });
+            expect((await getPublicUserData('canonical-user-id'))?.uid).toBe('canonical-user-id');
+
+            await setDoc(userDocRef, { uid: 'stale-user-id' }, { merge: true });
+            expect((await getPublicUserData('canonical-user-id'))?.uid).toBe('canonical-user-id');
+        } finally {
+            await deleteDoc(userDocRef);
+        }
     });
 
     test("Can be seen by other users", async () => {
@@ -532,6 +547,22 @@ describe('Committee Functions', () => {
 
         const committee = await getCommittee(testCommittee.firebaseDocName!);
         expect(committee).toMatchObject(testCommittee);
+    });
+
+    test('setCommitteeData persists only the selected leadership removals', async () => {
+        await setCommitteeData(testCommittee);
+
+        const updatedCommittee = {
+            ...testCommittee,
+            leads: removeCommitteeMemberUid(testCommittee.leads, 'lead1'),
+            representatives: removeCommitteeMemberUid(testCommittee.representatives, 'rep2'),
+        };
+
+        await setCommitteeData(updatedCommittee);
+        const reloadedCommittee = await getCommittee(testCommittee.firebaseDocName!);
+
+        expect(reloadedCommittee?.leads).toEqual(['lead2']);
+        expect(reloadedCommittee?.representatives).toEqual(['rep1']);
     });
 
     test('setCommitteeData throws error for non-existent head', async () => {

--- a/src/api/firebaseUtils.ts
+++ b/src/api/firebaseUtils.ts
@@ -36,8 +36,10 @@ export const getPublicUserData = async (uid: string = ""): Promise<PublicUserInf
 
     return getDoc(doc(db, "users", uid))
         .then(async (res) => {
-            const responseData = res.data()
-            return responseData;
+            const responseData = res.data();
+            return responseData
+                ? { ...responseData, uid: res.id } as PublicUserInfo
+                : undefined;
         })
         .catch(err => {
             console.error(err);

--- a/src/helpers/__tests__/committeeMembers.test.ts
+++ b/src/helpers/__tests__/committeeMembers.test.ts
@@ -1,0 +1,26 @@
+import {
+    CommitteeTeamMember,
+    removeCommitteeMemberUid,
+    removeCommitteeTeamMember,
+} from '../committeeMembers';
+
+const memberUids = ['lead-1', 'lead-2', 'lead-3'];
+const teamMembers: CommitteeTeamMember[] = memberUids.map(uid => ({
+    uid,
+    name: uid,
+}));
+
+describe('committee leadership member removal', () => {
+    test.each([
+        ['first', memberUids, 'lead-1', ['lead-2', 'lead-3']],
+        ['middle', memberUids, 'lead-2', ['lead-1', 'lead-3']],
+        ['last', memberUids, 'lead-3', ['lead-1', 'lead-2']],
+        ['only', ['lead-1'], 'lead-1', []],
+    ])('removes only the %s member from stored and hydrated state', (_position, storedUids, uidToRemove, expectedUids) => {
+        expect(removeCommitteeMemberUid(storedUids, uidToRemove)).toEqual(expectedUids);
+
+        const hydratedMembers = teamMembers.filter(member => storedUids.includes(member.uid));
+        expect(removeCommitteeTeamMember(hydratedMembers, uidToRemove).map(member => member.uid))
+            .toEqual(expectedUids);
+    });
+});

--- a/src/helpers/committeeMembers.ts
+++ b/src/helpers/committeeMembers.ts
@@ -6,6 +6,16 @@ export const isCommitteeTeamMember = (
     member: PublicUserInfo | undefined
 ): member is CommitteeTeamMember => Boolean(member?.uid);
 
+/**
+ * Fallback for a uid whose profile failed to hydrate (network/permission error,
+ * not a deleted user). Keeps the uid visible and removable instead of silently
+ * dropping it, which would let it get written back to Firestore unremovable.
+ */
+export const createFallbackTeamMember = (uid: string): CommitteeTeamMember => ({
+    uid,
+    name: `Unknown user (${uid})`,
+});
+
 export const removeCommitteeMemberUid = (
     memberUids: readonly string[] | undefined,
     uidToRemove: string

--- a/src/helpers/committeeMembers.ts
+++ b/src/helpers/committeeMembers.ts
@@ -1,0 +1,17 @@
+import { PublicUserInfo } from '../types/user';
+
+export type CommitteeTeamMember = PublicUserInfo & { uid: string };
+
+export const isCommitteeTeamMember = (
+    member: PublicUserInfo | undefined
+): member is CommitteeTeamMember => Boolean(member?.uid);
+
+export const removeCommitteeMemberUid = (
+    memberUids: readonly string[] | undefined,
+    uidToRemove: string
+): string[] => (memberUids || []).filter(uid => uid !== uidToRemove);
+
+export const removeCommitteeTeamMember = (
+    members: readonly CommitteeTeamMember[] | undefined,
+    uidToRemove: string
+): CommitteeTeamMember[] => (members || []).filter(member => member.uid !== uidToRemove);

--- a/src/screens/committees/CommitteeEditor.tsx
+++ b/src/screens/committees/CommitteeEditor.tsx
@@ -14,6 +14,7 @@ import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { StatusBar } from 'expo-status-bar';
 import { UserContext } from '../../context/UserContext';
 import { KeyboardAwareScrollView } from '@pietile-native-kit/keyboard-aware-scrollview';
+import { CommitteeTeamMember, isCommitteeTeamMember, removeCommitteeMemberUid, removeCommitteeTeamMember } from '../../helpers/committeeMembers';
 
 const CommitteeEditor = ({ navigation, route }: CommitteeEditorProps) => {
     const committeeData = route?.params?.committee;
@@ -64,19 +65,24 @@ const CommitteeEditor = ({ navigation, route }: CommitteeEditorProps) => {
                 const newTeamMembers: TeamMembersState = { leads: [], representatives: [], head: null };
 
                 if (head) {
-                    newTeamMembers.head = await getPublicUserData(head);
+                    const headData = await getPublicUserData(head);
+                    if (isCommitteeTeamMember(headData)) {
+                        newTeamMembers.head = headData;
+                    }
                 }
 
                 if (representatives && representatives.length > 0) {
-                    newTeamMembers.representatives = await Promise.all(
+                    const representativeData = await Promise.all(
                         representatives.map(async (uid) => await getPublicUserData(uid))
                     );
+                    newTeamMembers.representatives = representativeData.filter(isCommitteeTeamMember);
                 }
 
                 if (leads && leads.length > 0) {
-                    newTeamMembers.leads = await Promise.all(
+                    const leadData = await Promise.all(
                         leads.map(async (uid) => await getPublicUserData(uid))
                     );
+                    newTeamMembers.leads = leadData.filter(isCommitteeTeamMember);
                 }
                 setLocalTeamMembers(newTeamMembers);
             }
@@ -114,7 +120,7 @@ const CommitteeEditor = ({ navigation, route }: CommitteeEditorProps) => {
 
     const setHeadUserData = (uid: string,) => {
         const headInfo = teamMembers.find(member => member.uid === uid);
-        if (headInfo) {
+        if (isCommitteeTeamMember(headInfo)) {
             setLocalTeamMembers({
                 ...localTeamMembers,
                 head: headInfo
@@ -130,7 +136,7 @@ const CommitteeEditor = ({ navigation, route }: CommitteeEditorProps) => {
 
     const setLeadUserData = (uid: string) => {
         const leadInfo = leads.find(lead => lead.uid === uid);
-        if (leadInfo) {
+        if (isCommitteeTeamMember(leadInfo)) {
             setLocalTeamMembers(prevTeamMembers => ({
                 ...prevTeamMembers,
                 leads: [...(prevTeamMembers?.leads || []), leadInfo]
@@ -147,7 +153,7 @@ const CommitteeEditor = ({ navigation, route }: CommitteeEditorProps) => {
 
     const setRepresentativeUserData = (uid: string) => {
         const repInfo = representatives.find(rep => rep.uid === uid);
-        if (repInfo) {
+        if (isCommitteeTeamMember(repInfo)) {
             setLocalTeamMembers(prevTeamMembers => ({
                 ...prevTeamMembers,
                 representatives: [...(prevTeamMembers?.representatives || []), repInfo]
@@ -194,24 +200,24 @@ const CommitteeEditor = ({ navigation, route }: CommitteeEditorProps) => {
     const removeLead = (uid: string) => {
         setLocalCommitteeData(prevCommitteeData => ({
             ...prevCommitteeData,
-            leads: prevCommitteeData?.leads?.filter(existingUID => existingUID !== uid) || []
+            leads: removeCommitteeMemberUid(prevCommitteeData?.leads, uid)
         }));
 
         setLocalTeamMembers(prevTeamMembers => ({
             ...prevTeamMembers,
-            leads: prevTeamMembers?.leads?.filter(lead => lead?.uid !== uid) || []
+            leads: removeCommitteeTeamMember(prevTeamMembers?.leads, uid)
         }));
     };
 
     const removeRepresentative = (uid: string) => {
         setLocalCommitteeData(prevCommitteeData => ({
             ...prevCommitteeData,
-            representatives: prevCommitteeData?.representatives?.filter(existingUID => existingUID !== uid) || []
+            representatives: removeCommitteeMemberUid(prevCommitteeData?.representatives, uid)
         }));
 
         setLocalTeamMembers(prevTeamMembers => ({
             ...prevTeamMembers,
-            representatives: prevTeamMembers?.representatives?.filter(representative => representative?.uid !== uid) || []
+            representatives: removeCommitteeTeamMember(prevTeamMembers?.representatives, uid)
         }));
     };
 
@@ -441,13 +447,13 @@ const CommitteeEditor = ({ navigation, route }: CommitteeEditorProps) => {
                             </TouchableOpacity>
                         </View>
 
-                        {localTeamMembers.representatives?.map((representative, index) => (
-                            <View className='flex-row items-center mx-4 mt-3 justify-between' key={index}>
-                                <CommitteeTeamCard userData={representative!} />
+                        {localTeamMembers.representatives.map((representative) => (
+                            <View className='flex-row items-center mx-4 mt-3 justify-between' key={representative.uid}>
+                                <CommitteeTeamCard userData={representative} />
 
                                 <TouchableOpacity
                                     className='px-4'
-                                    onPress={() => { removeRepresentative(representative?.uid!) }}
+                                    onPress={() => { removeRepresentative(representative.uid) }}
                                 >
                                     <Octicons name="x" size={26} color="red" />
                                 </TouchableOpacity>
@@ -475,13 +481,13 @@ const CommitteeEditor = ({ navigation, route }: CommitteeEditorProps) => {
                             </TouchableOpacity>
                         </View>
 
-                        {localTeamMembers.leads?.map((lead, index) => (
-                            <View className='flex-row items-center mx-4 mt-3 justify-between' key={index}>
-                                <CommitteeTeamCard userData={lead!} />
+                        {localTeamMembers.leads.map((lead) => (
+                            <View className='flex-row items-center mx-4 mt-3 justify-between' key={lead.uid}>
+                                <CommitteeTeamCard userData={lead} />
 
                                 <TouchableOpacity
                                     className='px-4'
-                                    onPress={() => { removeLead(lead?.uid!) }}
+                                    onPress={() => { removeLead(lead.uid) }}
                                 >
                                     <Octicons name="x" size={26} color="red" />
                                 </TouchableOpacity>
@@ -820,9 +826,9 @@ const CommitteeEditor = ({ navigation, route }: CommitteeEditorProps) => {
 }
 
 interface TeamMembersState {
-    leads: (PublicUserInfo | undefined)[];
-    representatives: (PublicUserInfo | undefined)[];
-    head: PublicUserInfo | null | undefined;
+    leads: CommitteeTeamMember[];
+    representatives: CommitteeTeamMember[];
+    head: CommitteeTeamMember | null;
 }
 
 type CommitteeEditorProps = {

--- a/src/screens/committees/CommitteeEditor.tsx
+++ b/src/screens/committees/CommitteeEditor.tsx
@@ -14,7 +14,7 @@ import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { StatusBar } from 'expo-status-bar';
 import { UserContext } from '../../context/UserContext';
 import { KeyboardAwareScrollView } from '@pietile-native-kit/keyboard-aware-scrollview';
-import { CommitteeTeamMember, isCommitteeTeamMember, removeCommitteeMemberUid, removeCommitteeTeamMember } from '../../helpers/committeeMembers';
+import { CommitteeTeamMember, createFallbackTeamMember, isCommitteeTeamMember, removeCommitteeMemberUid, removeCommitteeTeamMember } from '../../helpers/committeeMembers';
 
 const CommitteeEditor = ({ navigation, route }: CommitteeEditorProps) => {
     const committeeData = route?.params?.committee;
@@ -66,23 +66,27 @@ const CommitteeEditor = ({ navigation, route }: CommitteeEditorProps) => {
 
                 if (head) {
                     const headData = await getPublicUserData(head);
-                    if (isCommitteeTeamMember(headData)) {
-                        newTeamMembers.head = headData;
-                    }
+                    newTeamMembers.head = isCommitteeTeamMember(headData)
+                        ? headData
+                        : createFallbackTeamMember(head);
                 }
 
                 if (representatives && representatives.length > 0) {
-                    const representativeData = await Promise.all(
-                        representatives.map(async (uid) => await getPublicUserData(uid))
+                    newTeamMembers.representatives = await Promise.all(
+                        representatives.map(async (uid) => {
+                            const data = await getPublicUserData(uid);
+                            return isCommitteeTeamMember(data) ? data : createFallbackTeamMember(uid);
+                        })
                     );
-                    newTeamMembers.representatives = representativeData.filter(isCommitteeTeamMember);
                 }
 
                 if (leads && leads.length > 0) {
-                    const leadData = await Promise.all(
-                        leads.map(async (uid) => await getPublicUserData(uid))
+                    newTeamMembers.leads = await Promise.all(
+                        leads.map(async (uid) => {
+                            const data = await getPublicUserData(uid);
+                            return isCommitteeTeamMember(data) ? data : createFallbackTeamMember(uid);
+                        })
                     );
-                    newTeamMembers.leads = leadData.filter(isCommitteeTeamMember);
                 }
                 setLocalTeamMembers(newTeamMembers);
             }


### PR DESCRIPTION
## Summary
- use Firestore document IDs as canonical user UIDs
- keep committee lead and representative removals synchronized between hydrated UI state and saved UID arrays
- use stable UID keys for leadership rows
- add regression coverage for first, middle, last, and only-member removals

## Testing
- committee member helper regression suite: 4 passed
- targeted Firebase emulator tests for canonical UID hydration and persisted leadership removals: 2 passed
- git diff check: passed
- repository-wide TypeScript checking still reports unrelated pre-existing errors; no errors reference the touched files